### PR TITLE
Adds the ability to cancel asynchronous commands

### DIFF
--- a/SimpleExec/Command-overloads.cs
+++ b/SimpleExec/Command-overloads.cs
@@ -1,5 +1,6 @@
 namespace SimpleExec
 {
+    using System.Threading;
     using System.Threading.Tasks;
 
     public static partial class Command
@@ -12,9 +13,18 @@ namespace SimpleExec
 
         public static Task RunAsync(string name, string args) => RunAsync(name, args, "", false);
 
+        public static Task RunAsync(string name, string args, CancellationToken cancellationToken) =>
+            RunAsync(name, args, "", false, cancellationToken);
+
         public static Task RunAsync(string name, string args, bool noEcho) => RunAsync(name, args, "", noEcho);
 
+        public static Task RunAsync(string name, string args, bool noEcho, CancellationToken cancellationToken) =>
+            RunAsync(name, args, "", noEcho, cancellationToken);
+
         public static Task RunAsync(string name, string args, string workingDirectory) => RunAsync(name, args, workingDirectory, false);
+
+        public static Task RunAsync(string name, string args, string workingDirectory, CancellationToken cancellationToken) =>
+            RunAsync(name, args, workingDirectory, false, cancellationToken);
 
         public static Task RunAsync(string name, string args, string workingDirectory, bool noEcho) =>
             RunAsync(name, args, workingDirectory, noEcho, default);
@@ -27,9 +37,18 @@ namespace SimpleExec
 
         public static Task<string> ReadAsync(string name, string args) => ReadAsync(name, args, "", false);
 
+        public static Task<string> ReadAsync(string name, string args, CancellationToken cancellationToken) =>
+            ReadAsync(name, args, "", false, cancellationToken);
+
         public static Task<string> ReadAsync(string name, string args, bool noEcho) => ReadAsync(name, args, "", noEcho);
 
+        public static Task<string> ReadAsync(string name, string args, bool noEcho, CancellationToken cancellationToken) =>
+            ReadAsync(name, args, "", noEcho, cancellationToken);
+
         public static Task<string> ReadAsync(string name, string args, string workingDirectory) => ReadAsync(name, args, workingDirectory, false);
+
+        public static Task<string> ReadAsync(string name, string args, string workingDirectory, CancellationToken cancellationToken) =>
+            ReadAsync(name, args, workingDirectory, false, cancellationToken);
 
         public static Task<string> ReadAsync(string name, string args, string workingDirectory, bool noEcho) =>
             ReadAsync(name, args, workingDirectory, noEcho, default);

--- a/SimpleExec/Command-overloads.cs
+++ b/SimpleExec/Command-overloads.cs
@@ -16,6 +16,9 @@ namespace SimpleExec
 
         public static Task RunAsync(string name, string args, string workingDirectory) => RunAsync(name, args, workingDirectory, false);
 
+        public static Task RunAsync(string name, string args, string workingDirectory, bool noEcho) =>
+            RunAsync(name, args, workingDirectory, noEcho, default);
+
         public static string Read(string name, string args) => Read(name, args, "", false);
 
         public static string Read(string name, string args, bool noEcho) => Read(name, args, "", noEcho);
@@ -27,5 +30,8 @@ namespace SimpleExec
         public static Task<string> ReadAsync(string name, string args, bool noEcho) => ReadAsync(name, args, "", noEcho);
 
         public static Task<string> ReadAsync(string name, string args, string workingDirectory) => ReadAsync(name, args, workingDirectory, false);
+
+        public static Task<string> ReadAsync(string name, string args, string workingDirectory, bool noEcho) =>
+            ReadAsync(name, args, workingDirectory, noEcho, default);
     }
 }

--- a/SimpleExec/Command.cs
+++ b/SimpleExec/Command.cs
@@ -1,6 +1,7 @@
 namespace SimpleExec
 {
     using System.Diagnostics;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public static partial class Command
@@ -19,14 +20,14 @@ namespace SimpleExec
             }
         }
 
-        public static async Task RunAsync(string name, string args, string workingDirectory, bool noEcho)
+        public static async Task RunAsync(string name, string args, string workingDirectory, bool noEcho, CancellationToken cancellationToken)
         {
             using (var process = new Process())
             {
                 process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false);
-                await process.RunAsync(noEcho).ConfigureAwait(false);
+                await process.RunAsync(noEcho, cancellationToken).ConfigureAwait(false);
 
-                if (process.ExitCode != 0)
+                if (process.ExitCode != 0 && !cancellationToken.IsCancellationRequested)
                 {
                     process.Throw();
                 }
@@ -49,14 +50,14 @@ namespace SimpleExec
             }
         }
 
-        public static async Task<string> ReadAsync(string name, string args, string workingDirectory, bool noEcho)
+        public static async Task<string> ReadAsync(string name, string args, string workingDirectory, bool noEcho, CancellationToken cancellationToken)
         {
             using (var process = new Process())
             {
                 process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true);
-                await process.RunAsync(noEcho).ConfigureAwait(false);
+                await process.RunAsync(noEcho, cancellationToken).ConfigureAwait(false);
 
-                if (process.ExitCode != 0)
+                if (process.ExitCode != 0 && !cancellationToken.IsCancellationRequested)
                 {
                     process.Throw();
                 }

--- a/SimpleExec/ProcessExtensions.cs
+++ b/SimpleExec/ProcessExtensions.cs
@@ -1,6 +1,7 @@
 namespace SimpleExec
 {
     using System;
+    using System.ComponentModel;
     using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
@@ -33,7 +34,14 @@ namespace SimpleExec
                     var currentProcess = (Process)state;
                     if (!currentProcess.HasExited)
                     {
-                        currentProcess.Kill();
+                        try
+                        {
+                            currentProcess.Kill();
+                        }
+
+                        // Eat the exception, because the process has already exited.
+                        catch (Win32Exception) { }
+                        catch (InvalidOperationException) { }
                     }
                 },
                 process

--- a/SimpleExec/ProcessExtensions.cs
+++ b/SimpleExec/ProcessExtensions.cs
@@ -28,7 +28,7 @@ namespace SimpleExec
 
         static CancellationTokenRegistration KillProcessOnCancellation(Process process, CancellationToken cancellationToken)
         {
-            return cancellationToken.Register(
+            var registration = cancellationToken.Register(
                 state =>
                 {
                     var currentProcess = (Process)state;
@@ -46,6 +46,11 @@ namespace SimpleExec
                 },
                 process
             );
+
+            // Attempt to dispose of the registration before the token is canceled
+            // to help prevent unnecessary exception handling.
+            process.Exited += (_, __) => registration.Dispose();
+            return registration;
         }
 
         private static void EchoAndStart(this Process process, bool noEcho)

--- a/SimpleExecTester/Program.cs
+++ b/SimpleExecTester/Program.cs
@@ -2,6 +2,7 @@ namespace SimpleExecTester
 {
     using System;
     using System.Linq;
+    using System.Threading;
 
     internal class Program
     {
@@ -13,6 +14,11 @@ namespace SimpleExecTester
             {
                 Console.Error.WriteLine($"SimpleExecTester (stderr): {string.Join(" ", args)}");
                 return 1;
+            }
+            else if (args.Length > 0 && int.TryParse(args[0], out var sleepInMilliseconds))
+            {
+                Thread.Sleep(sleepInMilliseconds);
+                return 0;
             }
 
             return 0;

--- a/SimpleExecTester/Program.cs
+++ b/SimpleExecTester/Program.cs
@@ -15,9 +15,9 @@ namespace SimpleExecTester
                 Console.Error.WriteLine($"SimpleExecTester (stderr): {string.Join(" ", args)}");
                 return 1;
             }
-            else if (args.Length > 0 && int.TryParse(args[0], out var sleepInMilliseconds))
+            else if (args.Contains("sleep"))
             {
-                Thread.Sleep(sleepInMilliseconds);
+                Thread.Sleep(Timeout.Infinite);
                 return 0;
             }
 

--- a/SimpleExecTests/CancellingCommands.cs
+++ b/SimpleExecTests/CancellingCommands.cs
@@ -29,7 +29,6 @@ namespace SimpleExecTests
             using (var cancellationTokenSource = new CancellationTokenSource(50))
             {
                 var result = await Command.ReadAsync("dotnet", $"exec {Tester.Path} 1000", "", false, cancellationTokenSource.Token);
-                Assert.Equal("", result);
             }
             watch.Stop();
             Assert.True(watch.Elapsed < TimeSpan.FromMilliseconds(1000), $"Command finished outside window in {watch.Elapsed}");

--- a/SimpleExecTests/CancellingCommands.cs
+++ b/SimpleExecTests/CancellingCommands.cs
@@ -1,15 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using SimpleExec;
-using SimpleExecTests.Infra;
-using Xunit;
-
 namespace SimpleExecTests
 {
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using SimpleExec;
+    using SimpleExecTests.Infra;
+    using Xunit;
+
     public class CancellingCommands
     {
         [Fact]

--- a/SimpleExecTests/CancellingCommands.cs
+++ b/SimpleExecTests/CancellingCommands.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using SimpleExec;
+using SimpleExecTests.Infra;
+using Xunit;
+
+namespace SimpleExecTests
+{
+    public class CancellingCommands
+    {
+        [Fact]
+        public async Task CancellingARunningCommandStopsCommand()
+        {
+            var watch = Stopwatch.StartNew();
+            using (var cancellationTokenSource = new CancellationTokenSource(50))
+            {
+                await Command.RunAsync("dotnet", $"exec {Tester.Path} 1000", "", false, cancellationTokenSource.Token);
+            }
+            watch.Stop();
+            Assert.True(watch.Elapsed < TimeSpan.FromMilliseconds(1000), $"Command finished outside window in {watch.Elapsed}");
+        }
+
+        [Fact]
+        public async Task CancellingAReadingCommandStopsCommand()
+        {
+            var watch = Stopwatch.StartNew();
+            using (var cancellationTokenSource = new CancellationTokenSource(50))
+            {
+                var result = await Command.ReadAsync("dotnet", $"exec {Tester.Path} 1000", "", false, cancellationTokenSource.Token);
+                Assert.Equal("", result);
+            }
+            watch.Stop();
+            Assert.True(watch.Elapsed < TimeSpan.FromMilliseconds(1000), $"Command finished outside window in {watch.Elapsed}");
+        }
+    }
+}

--- a/SimpleExecTests/CancellingCommands.cs
+++ b/SimpleExecTests/CancellingCommands.cs
@@ -16,7 +16,7 @@ namespace SimpleExecTests
             var watch = Stopwatch.StartNew();
             using (var cancellationTokenSource = new CancellationTokenSource(50))
             {
-                await Command.RunAsync("dotnet", $"exec {Tester.Path} 1000", "", false, cancellationTokenSource.Token);
+                await Command.RunAsync("dotnet", $"exec {Tester.Path} sleep", "", false, cancellationTokenSource.Token);
             }
             watch.Stop();
             Assert.True(watch.Elapsed < TimeSpan.FromMilliseconds(1000), $"Command finished outside window in {watch.Elapsed}");
@@ -28,7 +28,7 @@ namespace SimpleExecTests
             var watch = Stopwatch.StartNew();
             using (var cancellationTokenSource = new CancellationTokenSource(50))
             {
-                var result = await Command.ReadAsync("dotnet", $"exec {Tester.Path} 1000", "", false, cancellationTokenSource.Token);
+                var result = await Command.ReadAsync("dotnet", $"exec {Tester.Path} sleep", "", false, cancellationTokenSource.Token);
             }
             watch.Stop();
             Assert.True(watch.Elapsed < TimeSpan.FromMilliseconds(1000), $"Command finished outside window in {watch.Elapsed}");

--- a/SimpleExecTests/CancellingCommands.cs
+++ b/SimpleExecTests/CancellingCommands.cs
@@ -13,25 +13,19 @@ namespace SimpleExecTests
         [Fact]
         public async Task CancellingARunningCommandStopsCommand()
         {
-            var watch = Stopwatch.StartNew();
             using (var cancellationTokenSource = new CancellationTokenSource(50))
             {
                 await Command.RunAsync("dotnet", $"exec {Tester.Path} sleep", "", false, cancellationTokenSource.Token);
             }
-            watch.Stop();
-            Assert.True(watch.Elapsed < TimeSpan.FromMilliseconds(1000), $"Command finished outside window in {watch.Elapsed}");
         }
 
         [Fact]
         public async Task CancellingAReadingCommandStopsCommand()
         {
-            var watch = Stopwatch.StartNew();
             using (var cancellationTokenSource = new CancellationTokenSource(50))
             {
                 var result = await Command.ReadAsync("dotnet", $"exec {Tester.Path} sleep", "", false, cancellationTokenSource.Token);
             }
-            watch.Stop();
-            Assert.True(watch.Elapsed < TimeSpan.FromMilliseconds(1000), $"Command finished outside window in {watch.Elapsed}");
         }
     }
 }

--- a/SimpleExecTests/api-netcoreapp2_1.txt
+++ b/SimpleExecTests/api-netcoreapp2_1.txt
@@ -8,8 +8,11 @@ namespace SimpleExec
         public static string Read(string name, string args, string workingDirectory) { }
         public static string Read(string name, string args, string workingDirectory, bool noEcho) { }
         public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args) { }
+        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, bool noEcho) { }
+        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, bool noEcho, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, string workingDirectory) { }
+        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, string workingDirectory, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, string workingDirectory, bool noEcho) { }
         public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, string workingDirectory, bool noEcho, System.Threading.CancellationToken cancellationToken) { }
         public static void Run(string name, string args) { }
@@ -17,8 +20,11 @@ namespace SimpleExec
         public static void Run(string name, string args, string workingDirectory) { }
         public static void Run(string name, string args, string workingDirectory, bool noEcho) { }
         public static System.Threading.Tasks.Task RunAsync(string name, string args) { }
+        public static System.Threading.Tasks.Task RunAsync(string name, string args, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task RunAsync(string name, string args, bool noEcho) { }
+        public static System.Threading.Tasks.Task RunAsync(string name, string args, bool noEcho, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task RunAsync(string name, string args, string workingDirectory) { }
+        public static System.Threading.Tasks.Task RunAsync(string name, string args, string workingDirectory, System.Threading.CancellationToken cancellationToken) { }
         public static System.Threading.Tasks.Task RunAsync(string name, string args, string workingDirectory, bool noEcho) { }
         public static System.Threading.Tasks.Task RunAsync(string name, string args, string workingDirectory, bool noEcho, System.Threading.CancellationToken cancellationToken) { }
     }

--- a/SimpleExecTests/api-netcoreapp2_1.txt
+++ b/SimpleExecTests/api-netcoreapp2_1.txt
@@ -1,4 +1,4 @@
-﻿[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace SimpleExec
 {
     public class static Command
@@ -11,6 +11,7 @@ namespace SimpleExec
         public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, bool noEcho) { }
         public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, string workingDirectory) { }
         public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, string workingDirectory, bool noEcho) { }
+        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args, string workingDirectory, bool noEcho, System.Threading.CancellationToken cancellationToken) { }
         public static void Run(string name, string args) { }
         public static void Run(string name, string args, bool noEcho) { }
         public static void Run(string name, string args, string workingDirectory) { }
@@ -19,5 +20,6 @@ namespace SimpleExec
         public static System.Threading.Tasks.Task RunAsync(string name, string args, bool noEcho) { }
         public static System.Threading.Tasks.Task RunAsync(string name, string args, string workingDirectory) { }
         public static System.Threading.Tasks.Task RunAsync(string name, string args, string workingDirectory, bool noEcho) { }
+        public static System.Threading.Tasks.Task RunAsync(string name, string args, string workingDirectory, bool noEcho, System.Threading.CancellationToken cancellationToken) { }
     }
 }


### PR DESCRIPTION
Creates new APIs overloading `RunAsync` and `ReadAsync` for leveraging `CancellationToken` to allow consumers to cancel an asynchronous command by killing the process.