### PR TITLE
Handle large output when reading

### DIFF
--- a/SimpleExec/Command.cs
+++ b/SimpleExec/Command.cs
@@ -82,14 +82,18 @@ namespace SimpleExec
             using (var process = new Process())
             {
                 process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true);
-                process.Run(noEcho);
+
+                var runProcess = process.RunAsync(noEcho);
+                var readOutput = process.StandardOutput.ReadToEndAsync();
+
+                Task.WaitAll(runProcess, readOutput);
 
                 if (process.ExitCode != 0)
                 {
                     process.Throw();
                 }
 
-                return process.StandardOutput.ReadToEnd();
+                return readOutput.Result;
             }
         }
 
@@ -115,14 +119,18 @@ namespace SimpleExec
             using (var process = new Process())
             {
                 process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true);
-                await process.RunAsync(noEcho).ConfigureAwait(false);
+
+                var runProcess = process.RunAsync(noEcho);
+                var readOutput = process.StandardOutput.ReadToEndAsync();
+
+                await Task.WhenAll(runProcess, readOutput).ConfigureAwait(false);
 
                 if (process.ExitCode != 0)
                 {
                     process.Throw();
                 }
 
-                return await process.StandardOutput.ReadToEndAsync().ConfigureAwait(false);
+                return readOutput.Result;
             }
         }
     }

--- a/SimpleExecTester/Program.cs
+++ b/SimpleExecTester/Program.cs
@@ -9,6 +9,11 @@ namespace SimpleExecTester
         {
             Console.Out.WriteLine($"SimpleExecTester (stdout): {string.Join(" ", args)}");
 
+            if (args.Contains("large"))
+            {
+                Console.WriteLine(new string('x', (int)Math.Pow(2, 12)));
+            }
+
             if (args.Contains("error"))
             {
                 Console.Error.WriteLine($"SimpleExecTester (stderr): {string.Join(" ", args)}");

--- a/SimpleExecTests/ReadingCommands.cs
+++ b/SimpleExecTests/ReadingCommands.cs
@@ -8,20 +8,24 @@ namespace SimpleExecTests
     public class ReadingCommands
     {
         [Scenario]
-        public void ReadingACommand(string output)
+        [Example(false)]
+        [Example(true)]
+        public void ReadingACommand(bool largeOutput, string output)
         {
-            "When I read a succeeding command"
-                .x(() => output = Command.Read("dotnet", $"exec {Tester.Path} hello world"));
+            ("When I read a succeeding command" + (largeOutput ? " with large output" : ""))
+                .x(() => output = Command.Read("dotnet", $"exec {Tester.Path} hello world" + (largeOutput ? " large" : "")));
 
             "Then I see the command output"
                 .x(() => Assert.Contains("hello world", output));
         }
 
         [Scenario]
-        public void ReadingACommandAsync(string output)
+        [Example(false)]
+        [Example(true)]
+        public void ReadingACommandAsync(bool largeOutput, string output)
         {
-            "When I read a succeeding command"
-                .x(async () => output = await Command.ReadAsync("dotnet", $"exec {Tester.Path} hello world"));
+            ("When I read a succeeding command" + (largeOutput ? " with large output" : ""))
+                .x(async () => output = await Command.ReadAsync("dotnet", $"exec {Tester.Path} hello world"+ (largeOutput ? " large" : "")));
 
             "Then I see the command output"
                 .x(() => Assert.Contains("hello world", output));


### PR DESCRIPTION
As described in #108, when a process returns a large amount of output (several MB), special handling is required to avoid deadlocks in `System.Diagnostics.Process`.

Closes #108 
Closes #109