### PR TITLE
Windows-specific command name, arguments, and pass through

### DIFF
--- a/SimpleExec/Command.cs
+++ b/SimpleExec/Command.cs
@@ -16,16 +16,19 @@ namespace SimpleExec
         /// <param name="args">The arguments to pass to the command.</param>
         /// <param name="workingDirectory">The working directory in which to run the command.</param>
         /// <param name="noEcho">Whether or not to echo the resulting command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="windowsName">The name of the command to use on Windows only.</param>
+        /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
+        /// <param name="windowsPassthrough">Whether or not, on Windows only, the name of the command and the arguments are passed directly through to <see cref="System.Diagnostics.Process"/>, without substituting <c>cmd.exe</c> for the name of the command.</param>
         /// <exception cref="CommandException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = false)
+        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, bool windowsPassthrough = false)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs, windowsPassthrough);
                 process.Run(noEcho);
 
                 if (process.ExitCode != 0)
@@ -43,17 +46,20 @@ namespace SimpleExec
         /// <param name="args">The arguments to pass to the command.</param>
         /// <param name="workingDirectory">The working directory in which to run the command.</param>
         /// <param name="noEcho">Whether or not to echo the resulting command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="windowsName">The name of the command to use on Windows only.</param>
+        /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
+        /// <param name="windowsPassthrough">Whether or not, on Windows only, the name of the command and the arguments are passed directly through to <see cref="System.Diagnostics.Process"/>, without substituting <c>cmd.exe</c> for the name of the command.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous running of the command.</returns>
         /// <exception cref="CommandException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static async Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false)
+        public static async Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, bool windowsPassthrough = false)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs, windowsPassthrough);
                 await process.RunAsync(noEcho).ConfigureAwait(false);
 
                 if (process.ExitCode != 0)
@@ -71,17 +77,20 @@ namespace SimpleExec
         /// <param name="args">The arguments to pass to the command.</param>
         /// <param name="workingDirectory">The working directory in which to run the command.</param>
         /// <param name="noEcho">Whether or not to echo the resulting command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="windowsName">The name of the command to use on Windows only.</param>
+        /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
+        /// <param name="windowsPassthrough">Whether or not, on Windows only, the name of the command and the arguments are passed directly through to <see cref="System.Diagnostics.Process"/>, without substituting <c>cmd.exe</c> for the name of the command.</param>
         /// <returns>A <see cref="string"/> representing the contents of standard output (stdout).</returns>
         /// <exception cref="CommandException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = false)
+        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, bool windowsPassthrough = false)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs, windowsPassthrough);
 
                 var runProcess = process.RunAsync(noEcho);
                 var readOutput = process.StandardOutput.ReadToEndAsync();
@@ -105,6 +114,9 @@ namespace SimpleExec
         /// <param name="args">The arguments to pass to the command.</param>
         /// <param name="workingDirectory">The working directory in which to run the command.</param>
         /// <param name="noEcho">Whether or not to echo the resulting command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="windowsName">The name of the command to use on Windows only.</param>
+        /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
+        /// <param name="windowsPassthrough">Whether or not, on Windows only, the name of the command and the arguments are passed directly through to <see cref="System.Diagnostics.Process"/>, without substituting <c>cmd.exe</c> for the name of the command.</param>
         /// <returns>
         /// A <see cref="Task{string}"/> representing the asynchronous running of the command and reading of standard output (stdout).
         /// The task result contains the contents of standard output (stdout).
@@ -114,11 +126,11 @@ namespace SimpleExec
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static async Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false)
+        public static async Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, bool windowsPassthrough = false)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs, windowsPassthrough);
 
                 var runProcess = process.RunAsync(noEcho);
                 var readOutput = process.StandardOutput.ReadToEndAsync();

--- a/SimpleExec/ProcessStartInfo.cs
+++ b/SimpleExec/ProcessStartInfo.cs
@@ -5,12 +5,12 @@ namespace SimpleExec
     internal static class ProcessStartInfo
     {
         public static System.Diagnostics.ProcessStartInfo Create(
-            string name, string args, string workingDirectory, bool captureOutput) =>
+            string name, string args, string workingDirectory, bool captureOutput, string windowsName, string windowsArgs, bool windowsPassthrough) =>
             (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 ? new System.Diagnostics.ProcessStartInfo
                 {
-                    FileName = "cmd.exe",
-                    Arguments = $"/c \"\"{name}\" {args}\"",
+                    FileName = windowsPassthrough ? windowsName ?? name : "cmd.exe",
+                    Arguments = windowsPassthrough ? windowsArgs ?? args : $"/c \"\"{windowsName ?? name}\" {windowsArgs ?? args}\"",
                     WorkingDirectory = workingDirectory,
                     UseShellExecute = false,
                     RedirectStandardError = false,

--- a/SimpleExecTests/api-netcoreapp2_2.txt
+++ b/SimpleExecTests/api-netcoreapp2_2.txt
@@ -3,10 +3,10 @@ namespace SimpleExec
 {
     public class static Command
     {
-        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = False) { }
-        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False) { }
-        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = False) { }
-        public static System.Threading.Tasks.Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False) { }
+        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, bool windowsPassthrough = False) { }
+        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, bool windowsPassthrough = False) { }
+        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, bool windowsPassthrough = False) { }
+        public static System.Threading.Tasks.Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, bool windowsPassthrough = False) { }
     }
     public class NonZeroExitCodeException : System.Exception
     {


### PR DESCRIPTION
@dtitenko @damianh @pawelros @leastprivilege this is an idea to allow workarounds for the problems described in #119 and elsewhere.

It adds some optional params which allow you to do a few things.

### Specify a specific command for Windows only

```c#
Run("path/to/foo", "arg1 arg2", windowsName: "path/to/foo.exe");
```

### Specify specific args for Windows only

```c#
Run("path/to/foo", "arg1 arg2", windowsArgs: "arg1 arg2 windows-is-great");
```

### Pass the command name and args straight through, without using cmd.exe

```c#
Run("path/to/foo", "arg1 arg2", windowsPassthrough: true);
```

---

Using an appropriate combination of these optional params, it should be possible to work around any Windows weirdness to do with `exe` vs `bat` vs `cmd`, `npm` wrappers like `yarn`, quotes, PATH, etc. when required. The methods can continue to be used as they are today, but when you really need full control, you can have it.

What do you think?