### PR TITLE
replace cmd.exe usage with optional params for windows

### DIFF
--- a/SimpleExec/Command.cs
+++ b/SimpleExec/Command.cs
@@ -16,16 +16,18 @@ namespace SimpleExec
         /// <param name="args">The arguments to pass to the command.</param>
         /// <param name="workingDirectory">The working directory in which to run the command.</param>
         /// <param name="noEcho">Whether or not to echo the resulting command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="windowsName">The name of the command to use on Windows only.</param>
+        /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
         /// <exception cref="CommandException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = false)
+        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs);
                 process.Run(noEcho);
 
                 if (process.ExitCode != 0)
@@ -43,17 +45,19 @@ namespace SimpleExec
         /// <param name="args">The arguments to pass to the command.</param>
         /// <param name="workingDirectory">The working directory in which to run the command.</param>
         /// <param name="noEcho">Whether or not to echo the resulting command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="windowsName">The name of the command to use on Windows only.</param>
+        /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous running of the command.</returns>
         /// <exception cref="CommandException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static async Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false)
+        public static async Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs);
                 await process.RunAsync(noEcho).ConfigureAwait(false);
 
                 if (process.ExitCode != 0)
@@ -71,17 +75,19 @@ namespace SimpleExec
         /// <param name="args">The arguments to pass to the command.</param>
         /// <param name="workingDirectory">The working directory in which to run the command.</param>
         /// <param name="noEcho">Whether or not to echo the resulting command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="windowsName">The name of the command to use on Windows only.</param>
+        /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
         /// <returns>A <see cref="string"/> representing the contents of standard output (stdout).</returns>
         /// <exception cref="CommandException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = false)
+        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs);
 
                 var runProcess = process.RunAsync(noEcho);
                 var readOutput = process.StandardOutput.ReadToEndAsync();
@@ -105,6 +111,8 @@ namespace SimpleExec
         /// <param name="args">The arguments to pass to the command.</param>
         /// <param name="workingDirectory">The working directory in which to run the command.</param>
         /// <param name="noEcho">Whether or not to echo the resulting command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="windowsName">The name of the command to use on Windows only.</param>
+        /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
         /// <returns>
         /// A <see cref="Task{string}"/> representing the asynchronous running of the command and reading of standard output (stdout).
         /// The task result contains the contents of standard output (stdout).
@@ -114,11 +122,11 @@ namespace SimpleExec
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static async Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false)
+        public static async Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs);
 
                 var runProcess = process.RunAsync(noEcho);
                 var readOutput = process.StandardOutput.ReadToEndAsync();

--- a/SimpleExec/ProcessStartInfo.cs
+++ b/SimpleExec/ProcessStartInfo.cs
@@ -5,12 +5,12 @@ namespace SimpleExec
     internal static class ProcessStartInfo
     {
         public static System.Diagnostics.ProcessStartInfo Create(
-            string name, string args, string workingDirectory, bool captureOutput) =>
+            string name, string args, string workingDirectory, bool captureOutput, string windowsName, string windowsArgs) =>
             (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 ? new System.Diagnostics.ProcessStartInfo
                 {
-                    FileName = "cmd.exe",
-                    Arguments = $"/c \"\"{name}\" {args}\"",
+                    FileName = windowsName ?? name,
+                    Arguments = windowsArgs ?? args,
                     WorkingDirectory = workingDirectory,
                     UseShellExecute = false,
                     RedirectStandardError = false,

--- a/SimpleExec/SimpleExec.csproj
+++ b/SimpleExec/SimpleExec.csproj
@@ -5,7 +5,7 @@
     <Description>Runs external commands.</Description>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
-    <MinVerMinimumMajorMinor>4.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>6.0</MinVerMinimumMajorMinor>
     <PackageIconUrl>https://raw.githubusercontent.com/adamralph/simple-exec/master/assets/simple-exec.png</PackageIconUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/adamralph/simple-exec</PackageProjectUrl>

--- a/SimpleExecTests/api-netcoreapp2_2.txt
+++ b/SimpleExecTests/api-netcoreapp2_2.txt
@@ -3,10 +3,10 @@ namespace SimpleExec
 {
     public class static Command
     {
-        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = False) { }
-        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False) { }
-        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = False) { }
-        public static System.Threading.Tasks.Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False) { }
+        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null) { }
+        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null) { }
+        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null) { }
+        public static System.Threading.Tasks.Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null) { }
     }
     public class NonZeroExitCodeException : System.Exception
     {


### PR DESCRIPTION
`cmd.exe` is no longer used internally to execute commands on Windows.

There are two new optional parameters, `windowsName` and `windowsArgs`. If either the command name or arguments need to be different on Windows, they can be specified as arguments to these parameters. For example:

```c#
Run("foo", "bar", windowsName: "cmd.exe", windowsArgs: "/c foo bar");
```
