### PR TITLE
Add ability to configure the command's environment variables

### DIFF
--- a/SimpleExec/Command.cs
+++ b/SimpleExec/Command.cs
@@ -1,5 +1,7 @@
 namespace SimpleExec
 {
+    using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Threading.Tasks;
 
@@ -19,16 +21,17 @@ namespace SimpleExec
         /// <param name="windowsName">The name of the command to use on Windows only.</param>
         /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
         /// <param name="echoPrefix">The prefix to use when echoing the command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="configureEnvironment">An action which configures environment variables for the command.</param>
         /// <exception cref="NonZeroExitCodeException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null)
+        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null, Action<IDictionary<string, string>> configureEnvironment = null)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs, configureEnvironment);
                 process.Run(noEcho, echoPrefix ?? DefaultPrefix.Value);
 
                 if (process.ExitCode != 0)
@@ -49,17 +52,18 @@ namespace SimpleExec
         /// <param name="windowsName">The name of the command to use on Windows only.</param>
         /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
         /// <param name="echoPrefix">The prefix to use when echoing the command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="configureEnvironment">An action which configures environment variables for the command.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous running of the command.</returns>
         /// <exception cref="NonZeroExitCodeException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static async Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null)
+        public static async Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null, Action<IDictionary<string, string>> configureEnvironment = null)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs, configureEnvironment);
                 await process.RunAsync(noEcho, echoPrefix ?? DefaultPrefix.Value).ConfigureAwait(false);
 
                 if (process.ExitCode != 0)
@@ -80,17 +84,18 @@ namespace SimpleExec
         /// <param name="windowsName">The name of the command to use on Windows only.</param>
         /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
         /// <param name="echoPrefix">The prefix to use when echoing the command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="configureEnvironment">An action which configures environment variables for the command.</param>
         /// <returns>A <see cref="string"/> representing the contents of standard output (stdout).</returns>
         /// <exception cref="NonZeroExitCodeException">The command exited with non-zero exit code.</exception>
         /// <remarks>
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null)
+        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null, Action<IDictionary<string, string>> configureEnvironment = null)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs, configureEnvironment);
 
                 var runProcess = process.RunAsync(noEcho, echoPrefix ?? DefaultPrefix.Value);
                 var readOutput = process.StandardOutput.ReadToEndAsync();
@@ -117,6 +122,7 @@ namespace SimpleExec
         /// <param name="windowsName">The name of the command to use on Windows only.</param>
         /// <param name="windowsArgs">The arguments to pass to the command on Windows only.</param>
         /// <param name="echoPrefix">The prefix to use when echoing the command line and working directory (if specified) to standard error (stderr).</param>
+        /// <param name="configureEnvironment">An action which configures environment variables for the command.</param>
         /// <returns>
         /// A <see cref="Task{TResult}"/> representing the asynchronous running of the command and reading of standard output (stdout).
         /// The task result is a <see cref="string"/> representing the contents of standard output (stdout)
@@ -126,11 +132,11 @@ namespace SimpleExec
         /// By default, the resulting command line and the working directory (if specified) are echoed to standard error (stderr).
         /// To suppress this behavior, provide the <paramref name="noEcho"/> parameter with a value of <c>true</c>.
         /// </remarks>
-        public static async Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null)
+        public static async Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null, Action<IDictionary<string, string>> configureEnvironment = null)
         {
             using (var process = new Process())
             {
-                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs);
+                process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs, configureEnvironment);
 
                 var runProcess = process.RunAsync(noEcho, echoPrefix ?? DefaultPrefix.Value);
                 var readOutput = process.StandardOutput.ReadToEndAsync();

--- a/SimpleExec/ProcessStartInfo.cs
+++ b/SimpleExec/ProcessStartInfo.cs
@@ -1,12 +1,15 @@
 namespace SimpleExec
 {
+    using System;
+    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
     internal static class ProcessStartInfo
     {
         public static System.Diagnostics.ProcessStartInfo Create(
-            string name, string args, string workingDirectory, bool captureOutput, string windowsName, string windowsArgs) =>
-            RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            string name, string args, string workingDirectory, bool captureOutput, string windowsName, string windowsArgs, Action<IDictionary<string, string>> configureEnvironment)
+        {
+            var startInfo = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
                 ? new System.Diagnostics.ProcessStartInfo
                 {
                     FileName = windowsName ?? name,
@@ -25,5 +28,10 @@ namespace SimpleExec
                     RedirectStandardError = false,
                     RedirectStandardOutput = captureOutput
                 };
+
+            configureEnvironment?.Invoke(startInfo.Environment);
+
+            return startInfo;
+        }
     }
 }

--- a/SimpleExecTester/Program.cs
+++ b/SimpleExecTester/Program.cs
@@ -20,6 +20,8 @@ namespace SimpleExecTester
                 return 1;
             }
 
+            Console.WriteLine($"foo={Environment.GetEnvironmentVariable("foo")}");
+
             return 0;
         }
     }

--- a/SimpleExecTests/ConfiguringEnvironments.cs
+++ b/SimpleExecTests/ConfiguringEnvironments.cs
@@ -1,0 +1,23 @@
+namespace SimpleExecTests
+{
+    using SimpleExec;
+    using SimpleExecTests.Infra;
+    using Xbehave;
+    using Xunit;
+
+    public class ConfiguringEnvironments
+    {
+        [Scenario]
+        public void ConfiguringEnvironment(string output)
+        {
+            "When I read a command which echos the 'foo' environment variable and value"
+                .x(() => output = Command.Read(
+                    "dotnet",
+                    $"exec {Tester.Path} environment",
+                    configureEnvironment: env => env["foo"] = "bar"));
+
+            "Then I see the echoed 'foo' environment variable and value"
+                .x(() => Assert.Contains("foo=bar", output));
+        }
+    }
+}

--- a/SimpleExecTests/api.txt
+++ b/SimpleExecTests/api.txt
@@ -3,10 +3,10 @@ namespace SimpleExec
 {
     public class static Command
     {
-        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, string echoPrefix = null) { }
-        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, string echoPrefix = null) { }
-        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, string echoPrefix = null) { }
-        public static System.Threading.Tasks.Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, string echoPrefix = null) { }
+        public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, string echoPrefix = null, System.Action<System.Collections.Generic.IDictionary<string, string>> configureEnvironment = null) { }
+        public static System.Threading.Tasks.Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, string echoPrefix = null, System.Action<System.Collections.Generic.IDictionary<string, string>> configureEnvironment = null) { }
+        public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, string echoPrefix = null, System.Action<System.Collections.Generic.IDictionary<string, string>> configureEnvironment = null) { }
+        public static System.Threading.Tasks.Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = False, string windowsName = null, string windowsArgs = null, string echoPrefix = null, System.Action<System.Collections.Generic.IDictionary<string, string>> configureEnvironment = null) { }
     }
     public class NonZeroExitCodeException : System.Exception
     {


### PR DESCRIPTION
- Adds optional callback parameter `Action<IDictionary<string, string>>` to `Run` and `Read` overloads
- When creating the `ProcessStartInfo` calls the callback if not null
- Modify Tester project to echo a specific environment variable for tests
- Added test.

Fixes #174 