### PR TITLE
Reading a non-existent command throws an InvalidOperationException

### DIFF
--- a/SimpleExecTests/ReadingCommands.cs
+++ b/SimpleExecTests/ReadingCommands.cs
@@ -1,6 +1,7 @@
 namespace SimpleExecTests
 {
     using System;
+    using System.ComponentModel;
     using SimpleExec;
     using SimpleExecTests.Infra;
     using Xbehave;
@@ -58,6 +59,28 @@ namespace SimpleExecTests
 
             "And the exception contains the exit code"
                 .x(() => Assert.Equal(1, ((NonZeroExitCodeException)exception).ExitCode));
+        }
+
+        [Scenario]
+        public void ReadingANonExistentCommand(Exception exception)
+        {
+            "When I read a non-existent command"
+                .x(() => exception = Record.Exception(
+                    () => Command.Read("simple-exec-tests-non-existent-command")));
+
+            "Then a Win32Exception exception, of all things, is thrown"
+                .x(() => Assert.IsType<Win32Exception>(exception));
+        }
+
+        [Scenario]
+        public void ReadingANonExistentCommandAsync(Exception exception)
+        {
+            "When I read a non-existent command async"
+                .x(async () => exception = await Record.ExceptionAsync(
+                    () => Command.ReadAsync("simple-exec-tests-non-existent-command")));
+
+            "Then a Win32Exception exception, of all things, is thrown"
+                .x(() => Assert.IsType<Win32Exception>(exception));
         }
     }
 }


### PR DESCRIPTION
Reading a non-existent command throws an `InvalidOperationException`, instead of a `Win32Exception`, as with running a command