### PR TITLE
throw ArgumentException when command name missing

### DIFF
--- a/SimpleExec/Command.cs
+++ b/SimpleExec/Command.cs
@@ -31,6 +31,8 @@ namespace SimpleExec
         /// </remarks>
         public static void Run(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null, Action<IDictionary<string, string>> configureEnvironment = null, bool createNoWindow = false)
         {
+            Validate(name);
+
             using (var process = new Process())
             {
                 process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs, configureEnvironment, createNoWindow);
@@ -65,6 +67,8 @@ namespace SimpleExec
         /// </remarks>
         public static async Task RunAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null, Action<IDictionary<string, string>> configureEnvironment = null, bool createNoWindow = false, CancellationToken cancellationToken = default)
         {
+            Validate(name);
+
             using (var process = new Process())
             {
                 process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, false, windowsName, windowsArgs, configureEnvironment, createNoWindow);
@@ -102,6 +106,8 @@ namespace SimpleExec
         /// </remarks>
         public static string Read(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null, Action<IDictionary<string, string>> configureEnvironment = null, bool createNoWindow = false)
         {
+            Validate(name);
+
             using (var process = new Process())
             {
                 process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs, configureEnvironment, createNoWindow);
@@ -155,6 +161,8 @@ namespace SimpleExec
         /// </remarks>
         public static async Task<string> ReadAsync(string name, string args = null, string workingDirectory = null, bool noEcho = false, string windowsName = null, string windowsArgs = null, string echoPrefix = null, Action<IDictionary<string, string>> configureEnvironment = null, bool createNoWindow = false, CancellationToken cancellationToken = default)
         {
+            Validate(name);
+
             using (var process = new Process())
             {
                 process.StartInfo = ProcessStartInfo.Create(name, args, workingDirectory, true, windowsName, windowsArgs, configureEnvironment, createNoWindow);
@@ -180,6 +188,13 @@ namespace SimpleExec
                 }
 
                 return readOutput.Result;
+            }
+        }
+        private static void Validate(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("The command name is missing.", nameof(name));
             }
         }
     }

--- a/SimpleExecTests/ReadingCommands.cs
+++ b/SimpleExecTests/ReadingCommands.cs
@@ -82,5 +82,33 @@ namespace SimpleExecTests
             "Then a Win32Exception exception, of all things, is thrown"
                 .x(() => Assert.IsType<Win32Exception>(exception));
         }
+
+        [Scenario]
+        [Example(null)]
+        [Example("")]
+        [Example(" ")]
+        public void ReadingNoCommand(string name, Exception exception)
+        {
+            "When I read no command"
+                .x(() => exception = Record.Exception(
+                    () => Command.Read(name)));
+
+            "Then an ArgumentException exception is thrown"
+                .x(() => Assert.IsType<ArgumentException>(exception));
+        }
+
+        [Scenario]
+        [Example(null)]
+        [Example("")]
+        [Example(" ")]
+        public void ReadingNoCommandAsync(string name, Exception exception)
+        {
+            "When I read no command async"
+                .x(async () => exception = await Record.ExceptionAsync(
+                    () => Command.ReadAsync(name)));
+
+            "Then an ArgumentException exception is thrown"
+                .x(() => Assert.IsType<ArgumentException>(exception));
+        }
     }
 }

--- a/SimpleExecTests/RunningCommands.cs
+++ b/SimpleExecTests/RunningCommands.cs
@@ -92,5 +92,33 @@ namespace SimpleExecTests
             "Then a Win32Exception exception, of all things, is thrown"
                 .x(() => Assert.IsType<Win32Exception>(exception));
         }
+
+        [Scenario]
+        [Example(null)]
+        [Example("")]
+        [Example(" ")]
+        public void RunningNoCommand(string name, Exception exception)
+        {
+            "When I run no command"
+                .x(() => exception = Record.Exception(
+                    () => Command.Run(name)));
+
+            "Then an ArgumentException exception is thrown"
+                .x(() => Assert.IsType<ArgumentException>(exception));
+        }
+
+        [Scenario]
+        [Example(null)]
+        [Example("")]
+        [Example(" ")]
+        public void RunningNoCommandAsync(string name, Exception exception)
+        {
+            "When I run no command async"
+                .x(async () => exception = await Record.ExceptionAsync(
+                    () => Command.RunAsync(name)));
+
+            "Then an ArgumentException exception is thrown"
+                .x(() => Assert.IsType<ArgumentException>(exception));
+        }
     }
 }


### PR DESCRIPTION
Currently, an `InvalidOperationException` is thrown, which is propagated from `System.Diagnostics.Process.Start()`.

Breaking, since a different exception is now thrown in this scenario.