### PR TITLE
switch from netstandard2.0 to netstandard2.1

### DIFF
--- a/SimpleExec/SimpleExec.csproj
+++ b/SimpleExec/SimpleExec.csproj
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>https://github.com/adamralph/simple-exec/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
To safely and simply take advantage of new language features internally.

This is breaking since it [drops support for several platform versions](https://docs.microsoft.com/en-us/dotnet/standard/net-standard), including _all versions_ of .NET Framework. 👋

I'm doing this now because there is now an LTS successor to .NET Framework—[.NET 6](https://dotnet.microsoft.com/download/dotnet).