### PR TITLE
switch from netstandard2.1 to net6.0 and net7.0

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -23,7 +23,6 @@
     "langword",
     "markdownlint",
     "MyGet",
-    "netcoreapp",
     "netstandard",
     "NOLOGO",
     "NuGet",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       - uses: actions/setup-dotnet@v3.1.0
         with:
           dotnet-version: |
-            3.1.425
             6.0.403
             7.0.100
       - uses: actions/checkout@v3.5.2

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ SimpleExec is a [.NET library](https://www.nuget.org/packages/SimpleExec) that r
 
 SimpleExec intentionally does not invoke the system shell.
 
-Platform support: [.NET Standard 2.1 and later](https://docs.microsoft.com/en-us/dotnet/standard/net-standard).
+Platform support: [.NET 6.0 and later](https://docs.microsoft.com/en-us/dotnet/standard/net-standard).
 
 - [Quick start](#quick-start)
 - [Run](#run)

--- a/SimpleExec/ProcessExtensions.cs
+++ b/SimpleExec/ProcessExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -73,21 +74,21 @@ namespace SimpleExec
 
             if (!string.IsNullOrEmpty(info.WorkingDirectory))
             {
-                _ = builder.AppendLine($"{echoPrefix}: Working directory: {info.WorkingDirectory}");
+                _ = builder.AppendLine(CultureInfo.InvariantCulture, $"{echoPrefix}: Working directory: {info.WorkingDirectory}");
             }
 
             if (info.ArgumentList.Count > 0)
             {
-                _ = builder.AppendLine($"{echoPrefix}: {info.FileName}");
+                _ = builder.AppendLine(CultureInfo.InvariantCulture, $"{echoPrefix}: {info.FileName}");
 
                 foreach (var arg in info.ArgumentList)
                 {
-                    _ = builder.AppendLine($"{echoPrefix}:   {arg}");
+                    _ = builder.AppendLine(CultureInfo.InvariantCulture, $"{echoPrefix}:   {arg}");
                 }
             }
             else
             {
-                _ = builder.AppendLine($"{echoPrefix}: {info.FileName}{(string.IsNullOrEmpty(info.Arguments) ? "" : $" {info.Arguments}")}");
+                _ = builder.AppendLine(CultureInfo.InvariantCulture, $"{echoPrefix}: {info.FileName}{(string.IsNullOrEmpty(info.Arguments) ? "" : $" {info.Arguments}")}");
             }
 
             return builder.ToString();

--- a/SimpleExec/SimpleExec.csproj
+++ b/SimpleExec/SimpleExec.csproj
@@ -11,7 +11,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>https://github.com/adamralph/simple-exec/blob/main/CHANGELOG.md</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimpleExecTester/SimpleExecTester.csproj
+++ b/SimpleExecTester/SimpleExecTester.csproj
@@ -4,7 +4,7 @@
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <RollForward>major</RollForward>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
 </Project>

--- a/SimpleExecTests/Infra/Tester.cs
+++ b/SimpleExecTests/Infra/Tester.cs
@@ -3,12 +3,6 @@ namespace SimpleExecTests.Infra
     internal static class Tester
     {
         public static string Path =>
-#if NETCOREAPP3_1 && DEBUG
-            "../../../../SimpleExecTester/bin/Debug/netcoreapp3.1/SimpleExecTester.dll";
-#endif
-#if NETCOREAPP3_1 && RELEASE
-            "../../../../SimpleExecTester/bin/Release/netcoreapp3.1/SimpleExecTester.dll";
-#endif
 #if NET6_0 && DEBUG
             "../../../../SimpleExecTester/bin/Debug/net6.0/SimpleExecTester.dll";
 #endif

--- a/SimpleExecTests/SimpleExecTests.csproj
+++ b/SimpleExecTests/SimpleExecTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RollForward>major</RollForward>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
To safely and simply take advantage of new features.

I'm doing this now because the last version, .NET Core 3.1, [goes out of support](https://dotnet.microsoft.com/en-us/download/dotnet) on December 13, 2022.