### PR TITLE
Standard exception constructor equivalents

### DIFF
--- a/SimpleExec/ExitCodeException.cs
+++ b/SimpleExec/ExitCodeException.cs
@@ -3,16 +3,61 @@ namespace SimpleExec;
 /// <summary>
 /// The command exited with an unexpected exit code.
 /// </summary>
-/// <param name="exitCode">The exit code of the command.</param>
 #pragma warning disable CA1032 // Implement standard exception constructors
-public class ExitCodeException(int exitCode) : Exception
+public class ExitCodeException : Exception
 #pragma warning restore CA1032
 {
     /// <summary>
+    ///     Constructs an instance of a <see cref="ExitCodeException" />.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    public ExitCodeException(int exitCode) :
+        base(CreateMessage(exitCode)) =>
+        ExitCode = exitCode;
+
+    /// <summary>
+    ///     Constructs an instance of a <see cref="ExitCodeException" />.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    /// <param name="innerException">
+    ///     The exception that is the cause of the current exception,
+    ///     or a <c>null</c> reference (<c>Nothing</c> in Visual Basic) if no inner exception is specified.
+    /// </param>
+    public ExitCodeException(int exitCode, Exception innerException) :
+        base(CreateMessage(exitCode), innerException) =>
+        ExitCode = exitCode;
+
+    /// <summary>
+    ///     Constructs an instance of a <see cref="ExitCodeException" />.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    /// <param name="message">The message that describes the error.</param>
+    public ExitCodeException(int exitCode, string message) :
+        base(message) =>
+        ExitCode = exitCode;
+
+    /// <summary>
+    ///     Constructs an instance of a <see cref="ExitCodeException" />.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">
+    ///     The exception that is the cause of the current exception,
+    ///     or a <c>null</c> reference (<c>Nothing</c> in Visual Basic) if no inner exception is specified.
+    /// </param>
+    public ExitCodeException(int exitCode, string message, Exception innerException) :
+        base(message, innerException) =>
+        ExitCode = exitCode;
+
+    /// <summary>
     /// Gets the exit code of the command.
     /// </summary>
-    public int ExitCode { get; } = exitCode;
+    public int ExitCode { get; }
 
-    /// <inheritdoc/>
-    public override string Message => $"The command exited with code {ExitCode}.";
+    /// <summary>
+    /// Create the message that describes the error.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    /// <returns>The message that describes the error</returns>
+    protected static string CreateMessage(int exitCode) => $"The command exited with code {exitCode}.";
 }

--- a/SimpleExec/ExitCodeReadException.cs
+++ b/SimpleExec/ExitCodeReadException.cs
@@ -15,7 +15,62 @@ public class ExitCodeReadException : ExitCodeException
     /// <param name="exitCode">The exit code of the command.</param>
     /// <param name="standardOutput">The contents of standard output (stdout).</param>
     /// <param name="standardError">The contents of standard error (stderr).</param>
-    public ExitCodeReadException(int exitCode, string standardOutput, string standardError) : base(exitCode) => (StandardOutput, StandardError) = (standardOutput, standardError);
+    public ExitCodeReadException(int exitCode, string standardOutput, string standardError) :
+        base(exitCode, CreateMessage(exitCode, standardOutput, standardError))
+    {
+        StandardOutput = standardOutput;
+        StandardError = standardError;
+    }
+
+    /// <summary>
+    /// Constructs an instance of a <see cref="ExitCodeReadException"/>.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    /// <param name="standardOutput">The contents of standard output (stdout).</param>
+    /// <param name="standardError">The contents of standard error (stderr).</param>
+    /// <param name="innerException">
+    /// The exception that is the cause of the current exception,
+    /// or a <c>null</c> reference (<c>Nothing</c> in Visual Basic) if no inner exception is specified.
+    /// </param>
+    public ExitCodeReadException(int exitCode, string standardOutput, string standardError, Exception innerException) :
+        base(exitCode, CreateMessage(exitCode, standardOutput, standardError), innerException)
+    {
+        StandardOutput = standardOutput;
+        StandardError = standardError;
+    }
+
+    /// <summary>
+    /// Constructs an instance of a <see cref="ExitCodeReadException"/>.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    /// <param name="standardOutput">The contents of standard output (stdout).</param>
+    /// <param name="standardError">The contents of standard error (stderr).</param>
+    /// <param name="message">The message that describes the error.</param>
+    public ExitCodeReadException(int exitCode, string standardOutput, string standardError, string message) :
+        base(exitCode, message)
+    {
+        StandardOutput = standardOutput;
+        StandardError = standardError;
+    }
+
+    /// <summary>
+    /// Constructs an instance of a <see cref="ExitCodeReadException"/>.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    /// <param name="standardOutput">The contents of standard output (stdout).</param>
+    /// <param name="standardError">The contents of standard error (stderr).</param>
+    /// <param name="message">The message that describes the error.</param>
+    /// <param name="innerException">
+    /// The exception that is the cause of the current exception,
+    /// or a <c>null</c> reference (<c>Nothing</c> in Visual Basic) if no inner exception is specified.
+    /// </param>
+    public ExitCodeReadException(
+        int exitCode, string standardOutput, string standardError, string message, Exception innerException) :
+        base(exitCode, message, innerException)
+    {
+        StandardOutput = standardOutput;
+        StandardError = standardError;
+    }
 
     /// <summary>
     /// Gets the contents of standard output (stdout).
@@ -27,7 +82,13 @@ public class ExitCodeReadException : ExitCodeException
     /// </summary>
     public string StandardError { get; }
 
-    /// <inheritdoc/>
-    public override string Message =>
-        $"{base.Message}{TwoNewLines}Standard output (stdout):{TwoNewLines}{StandardOutput}{TwoNewLines}Standard error (stderr):{TwoNewLines}{StandardError}";
+    /// <summary>
+    /// Create the message that describes the error.
+    /// </summary>
+    /// <param name="exitCode">The exit code of the command.</param>
+    /// <param name="standardOutput">The contents of standard output (stdout).</param>
+    /// <param name="standardError">The contents of standard error (stderr).</param>
+    /// <returns>The message that describes the error</returns>
+    protected static string CreateMessage(int exitCode, string standardOutput, string standardError) =>
+        $"{CreateMessage(exitCode)}{TwoNewLines}Standard output (stdout):{TwoNewLines}{standardOutput}{TwoNewLines}Standard error (stderr):{TwoNewLines}{standardError}";
 }

--- a/SimpleExecTests/PublicApi.IsVerified.verified.txt
+++ b/SimpleExecTests/PublicApi.IsVerified.verified.txt
@@ -18,14 +18,20 @@
     public class ExitCodeException : System.Exception
     {
         public ExitCodeException(int exitCode) { }
+        public ExitCodeException(int exitCode, System.Exception innerException) { }
+        public ExitCodeException(int exitCode, string message) { }
+        public ExitCodeException(int exitCode, string message, System.Exception innerException) { }
         public int ExitCode { get; }
-        public override string Message { get; }
+        protected static string CreateMessage(int exitCode) { }
     }
     public class ExitCodeReadException : SimpleExec.ExitCodeException
     {
         public ExitCodeReadException(int exitCode, string standardOutput, string standardError) { }
-        public override string Message { get; }
+        public ExitCodeReadException(int exitCode, string standardOutput, string standardError, System.Exception innerException) { }
+        public ExitCodeReadException(int exitCode, string standardOutput, string standardError, string message) { }
+        public ExitCodeReadException(int exitCode, string standardOutput, string standardError, string message, System.Exception innerException) { }
         public string StandardError { get; }
         public string StandardOutput { get; }
+        protected static string CreateMessage(int exitCode, string standardOutput, string standardError) { }
     }
 }


### PR DESCRIPTION
| `Exception`                                                     | `ExitCodeException`                                                           | `ExitCodeReadException`                                                                                                    |
|-----------------------------------------------------------------|-------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
| `public NewException()`                                         | `public NewException(int exitCode)`                                           | `public NewException(int exitCode, string standardOutput, string standardError)`                                           |
| n/a                                                             | `public NewException(int exitCode, Exception innerException)`                 | `public NewException(int exitCode, string standardOutput, string standardError, Exception innerException)`                 |
| `public NewException(string message)`                           | `public NewException(int exitCode, string message)`                           | `public NewException(int exitCode, string standardOutput, string standardError, string message)`                           |
| `public NewException(string message, Exception innerException)` | `public NewException(int exitCode, string message, Exception innerException)` | `public NewException(int exitCode, string standardOutput, string standardError, string message, Exception innerException)` |

With convenience helpers for inheritors:

```csharp
protected static ExitCodeException.CreateMessage(
    int exitCode)

protected static ExitCodeReadException.CreateMessage(
    int exitCode, string standardOutput, string standardError)
```
